### PR TITLE
0.0.7: Update to *ring* 0.9.4.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "secure-session"
-version = "0.0.6"
+version = "0.0.7"
 authors = [ "heartsucker <heartsucker@autistici.org>" ]
 description = "Signed, encrypted session cookies for Iron"
 homepage = "https://github.com/heartsucker/rust-secure-session"
@@ -24,7 +24,7 @@ chrono = { version = "= 0.3.0", features = [ "serde" ] }
 cookie = { version = "0.6", features = [ "percent-encode" ] }
 iron = "0.5"
 log = "0.3"
-ring = "0.7"
+ring = "0.9.4"
 rust-crypto = "0.2"
 rustc-serialize = "0.3"
 serde = "0.9"

--- a/src/session.rs
+++ b/src/session.rs
@@ -7,7 +7,7 @@ use crypto::aes::KeySize;
 use crypto::aes_gcm::AesGcm;
 use crypto::chacha20poly1305::ChaCha20Poly1305;
 use crypto::scrypt::{scrypt, ScryptParams};
-use ring::rand::SystemRandom;
+use ring::rand::{SecureRandom, SystemRandom};
 use serde::de::Deserialize;
 use serde::ser::Serialize;
 use std::marker::PhantomData;


### PR DESCRIPTION
Before *ring* 0.9.3, it was possible to link multiple versions of *ring* into a program, e.g. if one version depended on *ring* 0.6 and another depended on *ring* 0.9. Unfortunately, this doesn't work, because the linker doesn't know to how to link *ring*'s C/asm code correctly in that kind of situation. *ring* 0.9.3 added a flag to its Cargo.toml to tell the Rust toolchain to stop allowing multiple versions of *ring* to be linked into the same program, to prevent any problems this may cause.

*ring* 0.9.4 was released with an update to make some crates easier to update to 0.9.x.